### PR TITLE
feat(cli): 命令支持传入未知的参数

### DIFF
--- a/src/bin/min.ts
+++ b/src/bin/min.ts
@@ -17,7 +17,7 @@ program
 commands.forEach(command => {
 
   // create command
-  let cmd = program.command(command.name)
+  let cmd = program.command(command.name).allowUnknownOption()
 
   // set alias
   if (command.alias) {


### PR DESCRIPTION
构建有时候需要传入一些额外的(项目)参数, 例如环境模式等自定义参数
目前传入会被 `commander.js` 认为是未知参数, 直接退出进程报错: error: unknown option `--env'